### PR TITLE
support arbitrary elements on set

### DIFF
--- a/lib/better_set/set.rb
+++ b/lib/better_set/set.rb
@@ -60,5 +60,9 @@ module BetterSet
     def powerset
       Values::Powerset.value(self)
     end
+
+    def arbitrary_element
+      @arbitrary_element ||= to_a.sample
+    end
   end
 end

--- a/lib/better_set/values/symmetry.rb
+++ b/lib/better_set/values/symmetry.rb
@@ -24,7 +24,7 @@ module BetterSet
       attr_reader :ordered_pairs
 
       def ordered_pair
-        @ordered_pair ||= ordered_pairs.to_a.first
+        @ordered_pair ||= ordered_pairs.arbitrary_element
       end
 
       def inverse_pair

--- a/spec/better_set/set_spec.rb
+++ b/spec/better_set/set_spec.rb
@@ -632,5 +632,24 @@ module BetterSet
         ))
       end
     end
+
+    describe "#arbitrary_element" do
+      let(:array) { [1,2,3,4] }
+      let(:set) { Set.new(*array) }
+
+      subject(:arbitrary_element) { set.arbitrary_element }
+
+      it "picks an element from the set" do
+        expect(array).to include(arbitrary_element)
+      end
+
+      it "doesnt return a new value on next call" do
+        element1 = set.arbitrary_element
+        element2 = set.arbitrary_element
+
+        expect(arbitrary_element).to eq(element1)
+        expect(arbitrary_element).to eq(element2)
+      end
+    end
   end
 end


### PR DESCRIPTION
this change allows for the extraction of an arbitrary element. once its been called, the value doesnt change. One use case for this is in the symmetry value class. we dont really need to take an particular element from the set, we just need an arbitrary element 